### PR TITLE
Readme: fixed: 'Available validators' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ String validation for iOS developed in Swift.
 + [Installation](#installation)
 + [Walkthrough](#walkthrough)
 + [Usage](#usage)
-+ [Available validators](#supported-functions)
++ [Available validators](#available-validators)
 + [License](#license-mit)
 
 ### ReactiveSwift + SwiftValidators


### PR DESCRIPTION
Corrected: `Available validators` link in `Contents` section of `Readme.md`.