### PR TITLE
Fix Xcode new build system compilation problem

### DIFF
--- a/SwiftValidators.podspec
+++ b/SwiftValidators.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SwiftValidators"
-  s.version          = "7.0.2"
+  s.version          = "7.0.3"
   s.summary          = "String validation for iOS developed in Swift"
   s.homepage         = "https://github.com/gkaimakas/SwiftValidators"
   s.license          = 'MIT'
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '9.0'
   s.requires_arc = true
 
-  s.source_files = 'Sources/**/*'
+  s.source_files = 'Sources/**/*.swift'
 
   s.frameworks = 'Foundation'
 


### PR DESCRIPTION
Include only swift files into source_files podspec to prevent compilation problems with new build system